### PR TITLE
Remove Google Tag Manager script

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-C7S1H1825N"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-C7S1H1825N');
-  </script>
   <meta charset="utf-8">
   <link rel="icon" type="image/jpg" href="favicon.jpg"/>
 


### PR DESCRIPTION
The cookies set by the Google Tag Manager script falls under statistical/performance cookies and require user consent. Since there is no consent form, the script has to come out.